### PR TITLE
Fix byte array initialization

### DIFF
--- a/uamodeler/uamodeler.py
+++ b/uamodeler/uamodeler.py
@@ -179,10 +179,10 @@ class UaModeler(QMainWindow):
         self.resize(int(self.settings.value("main_window_width", 800)),
                     int(self.settings.value("main_window_height", 600)))
         #self.restoreState(self.settings.value("main_window_state", b"", type="QByteArray"))
-        self.restoreState(self.settings.value("main_window_state", b""))
-        self.ui.splitterLeft.restoreState(self.settings.value("splitter_left", b""))
-        self.ui.splitterRight.restoreState(self.settings.value("splitter_right", b""))
-        self.ui.splitterCenter.restoreState(self.settings.value("splitter_center", b""))
+        self.restoreState(self.settings.value("main_window_state", bytearray()))
+        self.ui.splitterLeft.restoreState(self.settings.value("splitter_left", bytearray()))
+        self.ui.splitterRight.restoreState(self.settings.value("splitter_right", bytearray()))
+        self.ui.splitterCenter.restoreState(self.settings.value("splitter_center", bytearray()))
 
     def _disable_actions(self):
         self.ui.actionImport.setEnabled(False)


### PR DESCRIPTION
Using 0.2 I got the exception when opening for the first time:

```
Traceback (most recent call last):
  File "/usr/local/bin/opcua-modeler", line 9, in <module>
    load_entry_point('opcua-modeler==0.2', 'console_scripts', 'opcua-modeler')()
  File "/usr/local/lib/python3.5/dist-packages/uamodeler/uamodeler.py", line 434, in main
    modeler = UaModeler()
  File "/usr/local/lib/python3.5/dist-packages/uamodeler/uamodeler.py", line 58, in __init__
    self._restore_state()
  File "/usr/local/lib/python3.5/dist-packages/uamodeler/uamodeler.py", line 182, in _restore_state
    self.restoreState(self.settings.value("main_window_state", b""))
TypeError: restoreState(self, Union[QByteArray, bytes, bytearray], version: int = 0): argument 1 has unexpected type 'sip.voidptr'
```

This PR should fix it