### PR TITLE
another _recent_files fix

### DIFF
--- a/uamodeler/uamodeler.py
+++ b/uamodeler/uamodeler.py
@@ -416,7 +416,7 @@ class UaModeler(QMainWindow):
             self.update_recent_files(path)
 
     def update_recent_files(self, path):
-        if self._recent_files and path == self._recent_files[0]:
+        if not self._recent_files or path == self._recent_files[0]:
             return
         if path in self._recent_files:
             self._recent_files.remove(path)


### PR DESCRIPTION
When opening a xml file, it happened to me that it crashed because _recent_files was null. This change fixes the issue.